### PR TITLE
Skip symbolic links on POSIX platforms

### DIFF
--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -54,6 +54,8 @@ Executable hasktags
       directory >= 1.1 && < 1.3,
       filepath >= 1.3 && < 1.4,
       json >= 0.5 && < 0.8
+    if !os(windows)
+      Build-Depends: unix
     other-modules: Tags, Hasktags
     hs-source-dirs: src
     ghc-options: -Wall

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 module Main (main) where
 import Hasktags
@@ -9,6 +10,9 @@ import Data.List
 
 import System.IO
 import System.Directory
+#ifdef VERSION_unix
+import System.Posix.Files
+#endif
 import System.FilePath ((</>))
 import System.Console.GetOpt
 import System.Exit
@@ -98,6 +102,10 @@ dirToFiles named p = do
   case isD of
     False -> return $ if named || isHaskell then [p] else []
     True -> do
+#ifdef VERSION_unix
+      isL <- isSymbolicLink `fmap` getSymbolicLinkStatus p
+      if not named && isL then return [] else do
+#endif
         contents <- filter ((/=) "." . take 1) `fmap` getDirectoryContents p
         concat `fmap` mapM (dirToFiles False . (</>) p) contents
   where isHaskell = any (`isSuffixOf` p) [".hs", ".lhs"]


### PR DESCRIPTION
I have a fairly deep source tree and I leave symlinks around pointing to the top of the tree for convenience. Unfortunately this means dirToFiles never terminates, and I don't see a workaround.

System.Directory.doesDirectoryExist cannot discriminate between symlinks and real directories, so on non-Windows platforms we use System.Posix.Files.getSymbolicLinkStatus instead.

Bonus commits to fix upstream repository URL and a minor refactor of dirToFiles.
