### PR TITLE
Adds option to make paths in tags files absolute

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -109,6 +109,7 @@ data Mode = ExtendedCtag
           | FollowDirectorySymLinks
           | Help
           | HsSuffixes [String]
+          | AbsolutePath
           deriving (Ord, Eq, Show)
 
 data Token = Token String Pos


### PR DESCRIPTION
This is useful when using the --output flag since the tags file will be put
in some other yet the paths in said tags file will be relative to the
directory hasktags was called on. This makes the tags file almost
useless since vim and vim plugins (and emacs I guess?) will try to access those
relatives paths from within the directory where the tags files is
located.

For example, fugitive.vim loads tags file in your .git/ directory. So it
makes sense for you to call `hasktags -c --output=.git/tags .` on
git hooks and then let figutive.vim load the file. However, because
the paths are relative, it will try to look for them in
.git/{relative_path} instead of ./{relative_path}. Specifying the
absolute path solves this.

ctags has a `--tag-relative` flag that will actually set the paths to be
relative to where you place the output file. That sounds nice but I
fail to see the disadvantage of just calling the absolute path (beside
more text in your tags file) and figuring out how one path is relative to
another seems hard.
