### PR TITLE
Include `.hsc` in default suffixes.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,7 @@ import System.Exit
 import Control.Monad
 
 hsSuffixesDefault :: Mode
-hsSuffixesDefault =  HsSuffixes [ ".hs", ".lhs" ]
+hsSuffixesDefault =  HsSuffixes [ ".hs", ".lhs", ".hsc" ]
 
 options :: [OptDescr Mode]
 options = [ Option "c" ["ctags"]


### PR DESCRIPTION
This fix: https://github.com/aloiscochard/codex/issues/12

Hasktags seems to work perfectly on `hsc` file, it's quite important to tag them, for example when working with dependency like `hinotify`.