### PR TITLE
Bugfix removed data ctor (when --ignore-close-implementation) and add support for Vim+Tagbar scopes and signatures.

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -269,10 +269,12 @@ findThingsInBS ignoreCloseImpl filename bs = do
                                                && t2 == FTFuncImpl )
 
         let iCI = if ignoreCloseImpl
-              then nubBy (\(FoundThing _ n1 (Pos f1 l1 _ _) _ _)
-                         (FoundThing _ n2 (Pos f2 l2 _ _) _ _)
+              -- TODO it seems incidental that this keeps the defs (as desired) and not the impls.
+              then nubBy (\(FoundThing t1 n1 (Pos f1 l1 _ _) _ _)
+                         (FoundThing t2 n2 (Pos f2 l2 _ _) _ _)
                          -> f1 == f2
                            && n1 == n2
+                           && (FTFuncTypeDef ==) `any` [t1, t2]
                            && ((<= 7) $ abs $ l2 - l1))
               else id
         let things = iCI $ filterAdjacentFuncImpl $ concatMap findstuff $ map (\s -> trace_ "section in findThingsInBS" s s) sections

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -374,16 +374,16 @@ findstuff tokens@(Token "data" _ : Token name pos : xs)
         | otherwise
             =
               trace_  "findstuff data otherwise" tokens $
-              FoundThing FTData name pos nosig noscope
+              FoundThing FTData name pos (datasig xs) noscope
               : getcons ("data:" ++ name) FTCons (cleanupCons xs)  -- ++ (findstuff xs)
-findstuff tokens@(Token "newtype" _ : ts@(Token name pos : _)) =
+findstuff tokens@(Token "newtype" _ : ts@(Token name pos : xs)) =
         trace_ "findstuff newtype" tokens $
-        FoundThing FTNewtype name pos nosig noscope
+        FoundThing FTNewtype name pos (datasig xs) noscope
           : getcons ("newtype:" ++ name) FTCons (cleanupCons ts)  -- ++ (findstuff xs)
         -- FoundThing FTNewtype name pos : findstuff xs
 findstuff tokens@(Token "type" _ : Token name pos : xs) =
         trace_  "findstuff type" tokens $
-        FoundThing FTType name pos nosig noscope : findstuff xs
+        FoundThing FTType name pos (datasig xs) noscope : findstuff xs
 findstuff tokens@(Token "class" _ : xs) =
         trace_  "findstuff class" tokens $
         case (break ((== "where").tokenString) xs) of
@@ -495,6 +495,13 @@ conssig = decorateSignature . intercalate " "
         -- signature and the ends of the record fields.
         dropRecordArtifacts (s:xs) | s `elem` ["{", "}", ","] = xs
         dropRecordArtifacts xs = xs
+
+datasig :: [Token] -> Signature
+datasig = decorateSignature . intercalate " " . reverse . go []
+    where
+        go acc (Token "=" _ : _) = acc
+        go acc (Token s _ : xs) = go (s:acc) xs
+        go acc _ = acc
 
 splitByNL :: Maybe Int -> [Token] -> [[Token]]
 splitByNL maybeIndent (nl@(NewLine _):ts) =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,7 +7,6 @@ import System.Environment
 
 import Data.List
 
-import System.IO
 import System.Directory
 import System.Console.GetOpt
 import System.Exit

--- a/vim/plugin/tagbar-haskell.vim
+++ b/vim/plugin/tagbar-haskell.vim
@@ -1,0 +1,32 @@
+" This is a Haskell configuration for the Vim Tagbar plugin that uses
+" hasktags.
+
+if executable('hasktags')
+  let g:tagbar_type_haskell = {
+      \ 'ctagsbin'  : 'hasktags',
+      \ 'ctagsargs' : '-x -c --ignore-close-implementation -o-',
+      \ 'kinds'     : [
+          \  'm:modules:0:1',
+          \  'd:data: 0:1',
+          \  'd_gadt: data GADT:0:1',
+          \  't:type names:0:1',
+          \  'nt:newtypes:0:1',
+          \  'c:classes:0:1',
+          \  'cons:constructors:1:1',
+          \  'c_gadt:constructors (GADT):1:1',
+          \  'c_a:accessors:1:1',
+          \  'ft:function types:0:1',
+          \  'fi:function implementations:1:1',
+          \  'o:others:0:1'
+      \ ],
+      \ 'sro'        : '.',
+      \ 'kind2scope' : {
+          \ 'm' : 'module',
+          \ 'c' : 'class',
+          \ 'd' : 'data',
+          \ 'd_gadt' : 'GADT',
+          \ 'nt' : 'newtype',
+          \ 't' : 'type'
+      \ },
+      \ }
+endif


### PR DESCRIPTION
After the changes Tagbar takes up the tags and displays them like in the following picture:

![image](https://cloud.githubusercontent.com/assets/418830/6565847/6da16c38-c6b3-11e4-927e-6958ea6492ab.png)
