### PR TITLE
Feature/hidden files and folders support

### DIFF
--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -1,5 +1,5 @@
 Name: hasktags
-Version: 0.69.1
+Version: 0.69.2
 Copyright: The University Court of the University of Glasgow
 License: BSD3
 License-File: LICENSE

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -119,6 +119,7 @@ data Mode = ExtendedCtag
           | Help
           | HsSuffixes [String]
           | AbsolutePath
+          | IncludeHidden
           deriving (Ord, Eq, Show)
 
 data Token = Token String Pos
@@ -486,9 +487,9 @@ fromLiterate file lns =
         returnCode [] = [] -- unexpected - hasktags does tagging, not compiling, thus don't treat missing \end{code} to be an error
 
 -- suffixes: [".hs",".lhs"], use "" to match all files
-dirToFiles :: Bool -> [String] -> FilePath -> IO [ FilePath ]
-dirToFiles _ _ "STDIN" = fmap lines $ hGetContents stdin
-dirToFiles followSyms suffixes p = do
+dirToFiles :: Bool -> Bool -> [String] -> FilePath -> IO [ FilePath ]
+dirToFiles _ _ _ "STDIN" = fmap lines $ hGetContents stdin
+dirToFiles followSyms includeHidden suffixes p = do
   isD <- doesDirectoryExist p
   isSymLink <-
 #ifdef VERSION_unix
@@ -502,7 +503,9 @@ dirToFiles followSyms suffixes p = do
       if isSymLink && not followSyms
         then return []
         else do
-          -- filter . .. and hidden files .*
-          contents <- filter ((/=) '.' . head) `fmap` getDirectoryContents p
-          concat `fmap` (mapM (dirToFiles followSyms suffixes . (</>) p) contents)
+          -- filter . .. optionally also hidden files .*
+          let excludeDirectorySpecial item | includeHidden = notElem item [".", ".."]
+                                           | otherwise     = (/=) '.' $ head item
+          contents <- filter excludeDirectorySpecial `fmap` getDirectoryContents p
+          concat `fmap` (mapM (dirToFiles followSyms includeHidden suffixes . (</>) p) contents)
   where matchingSuffix = any (`isSuffixOf` p) suffixes

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,6 +43,7 @@ options = [ Option "c" ["ctags"]
           , Option "L" ["follow-symlinks"] (NoArg FollowDirectorySymLinks) "follow symlinks when recursing directories"
           , Option "S" ["suffixes"] (OptArg suffStr ".hs,.lhs") "list of hs suffixes including \".\""
           , Option "R" ["tags-absolute"] (NoArg AbsolutePath) "make tags paths absolute. Useful when setting tags files in other directories"
+          , Option "i" ["include-hidden"] (NoArg IncludeHidden) "includes hidden files and folders during search"
           , Option "h" ["help"] (NoArg Help) "This help"
           ]
   where suffStr Nothing = hsSuffixesDefault
@@ -79,9 +80,10 @@ main = do
         let hsSuffixes = head $ [ s | (HsSuffixes s) <- modes ++ [hsSuffixesDefault] ]
 
         let followSymLinks = FollowDirectorySymLinks `elem` modes
+        let includeHidden  = IncludeHidden `elem` modes
 
         filenames
-          <- liftM (nub . concat) $ mapM (dirToFiles followSymLinks hsSuffixes) files_or_dirs
+          <- liftM (nub . concat) $ mapM (dirToFiles followSymLinks includeHidden hsSuffixes) files_or_dirs
 
         when (errs /= [] || elem Help modes || files_or_dirs == [])
              (do putStr $ unlines errs


### PR DESCRIPTION
I would like to have this feature pulled in because I'm unpacking my dependencies in the cabal sandbox and would like to include them in the tagsfile generation.

I welcome any proposed changes since this a patch (in the "hack" sort of way) and not necessarily in line of the way you'd integrate this change.
