### PR TITLE
Ignore '=' in comments of data constructors

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -438,7 +438,6 @@ getcons _ [] = []
 getcons2 :: [Token] -> [FoundThing]
 getcons2 (Token name pos : Token "::" _ : xs) =
         FoundThing FTConsAccessor name pos : getcons2 xs
-getcons2 (Token "=" _ : _) = []
 getcons2 (Token "|" _ : Token name pos : xs) =
         FoundThing FTCons name pos : getcons2 xs
 getcons2 (_:xs) = getcons2 xs


### PR DESCRIPTION
First some code archeology. (Going by GHC's [.mailmap](https://git.haskell.org/ghc.git/blob/bc83c733e58939e1ff0d5eea9dca359615203ea4:/.mailmap#l202) file, the original author of hasktags was most likely [Rob Ennals](http://ennals.org/rob/index.html) (rje), a student of Simon Peyton Jones at the time).

The line I'm removing here was already present in the first version of hasktags:
https://git.haskell.org/ghc.git/commit/2744e4fb443cbfe1f3eeeb781079382071ca3cda

The idea was, I think, that finding a second '=' while processing the
constructor list of a data type declaration, must mean that we are done
processing that type.

```
data Foo =
  | C1
  | C2

x = 1    -- This equals sign means we are done processing 'Foo'

y | True = 2   -- So 'True' is not reported as a constructor of 'Foo'.
```

Nowadays, hasktags is much better at detecting where data type
declaration start and end, and the crude detection of '=' in getcons2 is
not necessary anymore.

This fixes #20. Here is a testcase:

```
data Bar
   = T1       -- because this comment contains an equals sign (=)
   | T2       -- hasktags didn't report 'T2' as a constructor
```

The tests in the testcases directory are unaffected.
