### PR TITLE
src/Hasktags.hs: tweak for ghc-8

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -35,7 +35,7 @@ import Control.Monad
 import DebugShow
 
 #ifdef VERSION_unix
-import System.Posix.Files
+import System.Posix.Files as SPF
 #endif
 import System.FilePath ((</>))
 
@@ -492,7 +492,7 @@ dirToFiles followSyms suffixes p = do
   isD <- doesDirectoryExist p
   isSymLink <-
 #ifdef VERSION_unix
-    isSymbolicLink `fmap` getSymbolicLinkStatus p
+    SPF.isSymbolicLink `fmap` getSymbolicLinkStatus p
 #else
     return False
 #endif


### PR DESCRIPTION
directory-1.2.6.0 (comes with ghc-8.0.1)
now includes 'isSymbolicLink' helper.

Guard against symbol collisison:

  src/Hasktags.hs:495:5: error:
    Ambiguous occurrence ‘isSymbolicLink’
    It could refer to either ‘System.Directory.isSymbolicLink’,
                             imported from ‘System.Directory’ at src/Hasktags.hs:31:1-23
                          or ‘System.Posix.Files.isSymbolicLink’,
                             imported from ‘System.Posix.Files’ at src/Hasktags.hs:38:1-25
                             (and originally defined in ‘unix-2.7.2.0:System.Posix.Files.Common’)

Signed-off-by: Sergei Trofimovich <siarheit@google.com>