### PR TITLE
Add !MIN_VERSION_directory(1,2,6) guard around isSymbolicLink

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -34,7 +34,7 @@ import Control.Monad
 
 import DebugShow
 
-#ifdef VERSION_unix
+#if !MIN_VERSION_directory(1,2,6) && defined(VERSION_unix)
 import System.Posix.Files
 #endif
 import System.FilePath ((</>))
@@ -491,7 +491,7 @@ dirToFiles _ _ "STDIN" = fmap lines $ hGetContents stdin
 dirToFiles followSyms suffixes p = do
   isD <- doesDirectoryExist p
   isSymLink <-
-#ifdef VERSION_unix
+#if !MIN_VERSION_directory(1,2,6) && defined(VERSION_unix)
     isSymbolicLink `fmap` getSymbolicLinkStatus p
 #else
     return False


### PR DESCRIPTION
isSymbolicLink is added in System.Directory since 1.2.6, causing ambiguous
occurrence ‘isSymbolicLink’ error.