### PR TITLE
Remove the `test` executable.

### DIFF
--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -85,27 +85,6 @@ Executable hasktags
   if flag(debug)
     cpp-options: -Ddebug
 
-Executable test
-    Main-Is: Test.hs
-    Build-Depends:
-      utf8-string,
-      base,
-      bytestring,
-      directory,
-      filepath,
-      json,
-      HUnit
-    other-modules: Tags, Hasktags, DebugShow
-    hs-source-dirs: src, tests
-    ghc-options: -Wall
-    default-language: Haskell2010
-
-  if !os(windows)
-    build-depends: unix
-
-  if flag(debug)
-    cpp-options: -Ddebug
-
 Test-Suite testsuite
   Type: exitcode-stdio-1.0
   Main-Is: Test.hs
@@ -122,6 +101,9 @@ Test-Suite testsuite
   other-modules: Tags, Hasktags, DebugShow
   ghc-options: -Wall
   default-language: Haskell2010
+
+  if !os(windows)
+    build-depends: unix
 
   if flag(debug)
     cpp-options: -Ddebug


### PR DESCRIPTION
- It looks identical to `testsuite` so I see no point in having both. I
  particularly don't see any point in installing it.

Signed-off-by: Magnus Therning <magnus@therning.org>