### PR TITLE
Add --options, --version and refactor

### DIFF
--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -77,7 +77,8 @@ Executable hasktags
       directory,
       filepath,
       hasktags,
-      optparse-applicative
+      optparse-applicative,
+      containers
     ghc-options: -Wall
     default-language: Haskell2010
 

--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -76,7 +76,8 @@ Executable hasktags
       base,
       directory,
       filepath,
-      hasktags
+      hasktags,
+      optparse-applicative
     ghc-options: -Wall
     default-language: Haskell2010
 

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -117,6 +117,7 @@ data Tags =
     Ctags
   | Etags
   | Both
+  deriving Show
 
 data Mode = Mode
   { _tags             :: Tags
@@ -127,7 +128,7 @@ data Mode = Mode
   , _followSymlinks   :: Bool
   , _suffixes         :: [String]
   , _absoluteTagPaths :: Bool
-  }
+  } deriving Show
 
 data Token = Token String Pos
             | NewLine Int -- space 8*" " = "\t"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,7 +38,7 @@ options = Options
       <*> suffixes
       <*> absoluteTagPaths
     ctags :: Parser Tags
-    ctags = flag Both Etags $
+    ctags = flag Both Ctags $
          long "ctags"
       <> short 'c'
       <> help "generate CTAGS file (ctags)"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -71,21 +71,21 @@ main = do
 #endif
 
         files_or_dirs <- if AbsolutePath `elem` modes
-                             then sequence $ map canonicalizePath files_or_dirs_unexpanded
+                             then mapM canonicalizePath files_or_dirs_unexpanded
                              else return files_or_dirs_unexpanded
-        let hsSuffixes = head $ [ s | (HsSuffixes s) <- modes ++ [hsSuffixesDefault] ]
+        let hsSuffixes = head [ s | (HsSuffixes s) <- modes ++ [hsSuffixesDefault] ]
 
         let followSymLinks = FollowDirectorySymLinks `elem` modes
 
         filenames
-          <- liftM (nub . concat) $ mapM (dirToFiles followSymLinks hsSuffixes) files_or_dirs
+          <- (nub . concat) <$> mapM (dirToFiles followSymLinks hsSuffixes) files_or_dirs
 
-        when (errs /= [] || elem Help modes || files_or_dirs == [])
+        when (errs /= [] || elem Help modes || null files_or_dirs)
              (do putStr $ unlines errs
                  putStr $ usageInfo usageString options
                  exitWith (ExitFailure 1))
 
-        when (filenames == []) $ putStrLn "warning: no files found!"
+        when (null filenames) $ putStrLn "warning: no files found!"
 
         generate modes filenames
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,16 +4,19 @@
 module Main (main) where
 import Hasktags
 
+import Control.Monad (unless)
 import Data.Monoid
 import Data.Set (Set, notMember, fromList, union)
-import qualified Data.Set as Set
-import Control.Monad (unless)
+import Data.Version (showVersion)
 import Options.Applicative
 import Options.Applicative.Help.Pretty (text, line)
-import System.IO (IOMode (AppendMode, WriteMode))
+import Paths_hasktags (version)
 import System.Directory (doesFileExist)
 import System.Environment (getArgs)
 import System.Exit (die)
+import System.IO (IOMode (AppendMode, WriteMode))
+
+import qualified Data.Set as Set
 
 data Options = Options
   { _mode :: Mode
@@ -147,13 +150,17 @@ parseArgs args parsedOptionFiles = do
         parseArgsFromFile :: FilePath -> IO [Argument]
         parseArgsFromFile fp = lines <$> readFile fp
 
-    opts = info (options <**> helper) $
+    opts = info (options <**> versionFlag <**> helper) $
          fullDesc
       <> progDescDoc (Just $
              replaceDirsInfo <> line <> line
           <> symlinksInfo <> line <> line
           <> stdinInfo)
       where
+        versionFlag = infoOption (showVersion version) $
+             long "version"
+          <> help "show version"
+
         replaceDirsInfo = text $ "directories will be replaced by DIR/**/*.hs DIR/**/*.lhs"
           ++ "Thus hasktags . tags all important files in the current directory."
         symlinksInfo = text $ "If directories are symlinks they will not be followed"

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -7,8 +7,7 @@ module Tags where
 import           Control.Monad       (when)
 import           Data.Char           (isSpace)
 import           Data.Data           (Data, Typeable)
-import           Data.List           (sortBy)
-import           Data.List           (intercalate)
+import           Data.List           (sortBy, intercalate)
 import           Lens.Micro.Platform
 import           System.IO           (Handle, hPutStr, hPutStrLn)
 

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -147,8 +147,8 @@ dumpThing cond thing = if cond
                           else normalDump thing
 
 -- stuff for dealing with ctags output format
-writectagsfile :: Handle -> Bool -> [FileData] -> IO ()
-writectagsfile ctagsfile extended filedata = do
+writectagsfile :: Bool -> [FileData] -> Handle -> IO ()
+writectagsfile extended filedata ctagsfile = do
     let things = concatMap getfoundthings filedata
     when extended
          (do hPutStrLn
@@ -171,8 +171,8 @@ sortThings = sortBy comp
 
 -- stuff for dealing with etags output format
 
-writeetagsfile :: Handle -> [FileData] -> IO ()
-writeetagsfile etagsfile = mapM_ (hPutStr etagsfile . etagsDumpFileData)
+writeetagsfile :: [FileData] -> Handle -> IO ()
+writeetagsfile fileData etagsfile = mapM_ (hPutStr etagsfile . etagsDumpFileData) fileData
 
 etagsDumpFileData :: FileData -> String
 etagsDumpFileData (FileData filename things) =


### PR DESCRIPTION
Hi,

I would like to make Hasktags more compatible with the vim plugin vim-gutentags (https://github.com/ludovicchabant/vim-gutentags). I think that vim-gutentags is quite a nice plugin with some very handy features and it would be great if people could easily use it together with Hasktags.

Part of the requirements that vim-gutentags have is that the tags generator must support `--options` and `--recurse`. There are some more flags that are required for features such as giving custom commands for which files to parse, in that case you would need `-L`, and `-L` would take a file which contains files for which tags should be generated.

I set out to implement `--options` as a first step. `GetOpt` is really hard to work with so I ended up changing it for `optparse-applicative` which I think looks really nice. I've implemented `--options` and I've fixed the changes that `hlint`.

So what I'm wondering:
* Is this something that you want?
* If yes, is this PR to big? I have separated branches for everything so I could split them up. The reason for creating a big PR like this was to maybe get a better overview.

If you think that this is good, then I can:
* Add recurse so that `vim-gutentags` can use Hasktags
* Maybe change the behaviour of `-L`, but then that would require a new major version I guess

Thanks in advance