### PR TITLE
Fix for issue #53 (see details in comments for the issue)

### DIFF
--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -77,6 +77,7 @@ Executable hasktags
       directory,
       filepath,
       hasktags
+    other-modules: Paths_hasktags
     ghc-options: -Wall
     default-language: Haskell2010
 

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -416,7 +416,9 @@ findFuncTypeDefs found xs@(Token "(" _ :_) scope =
           case break myBreakF xs of
             (inner@(Token _ p : _), rp : xs') ->
               let merged = Token ( concatMap (\(Token x _) -> x) $ inner ++ [rp] ) p
-              in findFuncTypeDefs found (merged : xs') scope
+              in if any (isNewLine Nothing) inner
+                   then []
+                   else findFuncTypeDefs found (merged : xs') scope
             _ -> []
     where myBreakF (Token ")" _) = True
           myBreakF _             = False


### PR DESCRIPTION
Expose module Paths_hasktags in other-modules for hasktags executable
to make cabal happy and quiet