### PR TITLE
README: do not mention --ignore-close-implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ hasktags --etags .
 
 Both formats:
 ```bash
-hasktags --ignore-close-implementation .
+hasktags --both .
 ```
 
 *NB:* Generating both tags generates a file called `TAGS` for Emacs, and one called `ctags` for Vim.


### PR DESCRIPTION
`ignore-close-implementation` was made the default and removed in https://github.com/MarcWeber/hasktags/issues/7