### PR TITLE
Switch back to strict ByteStrings

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -15,8 +15,8 @@ module Hasktags (
   dirToFiles
 ) where
 import           Control.Monad              (when)
-import qualified Data.ByteString.Lazy.Char8 as BS (ByteString, readFile, unpack)
-import qualified Data.ByteString.Lazy.UTF8  as BS8 (fromString)
+import qualified Data.ByteString.Char8 as BS (ByteString, readFile, unpack)
+import qualified Data.ByteString.UTF8  as BS8 (fromString)
 import           Data.Char                  (isSpace)
 import           Data.List                  (isPrefixOf, isSuffixOf, groupBy,
                                              tails)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -8,7 +8,7 @@ import           Data.List
 import           System.Directory
 import           System.Exit
 
-import qualified Data.ByteString.Lazy.Char8 as BS
+import qualified Data.ByteString.Char8 as BS
 
 import           Test.HUnit
 


### PR DESCRIPTION
Lazy ByteStrings fail on large projects due to too many open files. The error message:

    openBinaryFile: resource exhausted (Too many open files)

Fixes #57.

----

`hasktags` is a very important development tool. AFAIK, it's _the_ go-to tool for navigating Haskell codebases.

The project I'm working on has 50K+ SLOC of Haskell code. `hasktags` is the most efficient way to navigate it.  After I updated `hasktags` recently, I discovered that it doesn't work with my project any more.

@jhenahan [wrote](https://github.com/MarcWeber/hasktags/issues/57#issuecomment-408526635):

> Yup, this happened when I switched from strict to lazy bystestrings. It led to much better performance characteristics, but it seems to be a bit sloppier about managing file handles.

“Make it work” is way more important than “make it work fast”. :)

The problem [had been reported](https://github.com/MarcWeber/hasktags/commit/a0b21c58896954763c819aaaac59ea97137488bb#commitcomment-29218608) almost 3 months ago... Let us fix it, shall we?