### PR TITLE
A better fix for issue #53

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -414,11 +414,10 @@ findFuncTypeDefs found (t@(Token _ _): Token "::" _ : sig) scope =
 findFuncTypeDefs found xs@(Token "(" _ :_) scope =
           case break myBreakF xs of
             (inner@(Token _ p : _), rp : xs') ->
-              let merged = Token ( concatMap (\z -> case z of
-                                                 (Token x _) -> x
-                                                 (NewLine _) -> "")
-                                   $ inner ++ [rp] ) p
-              in findFuncTypeDefs found (merged : xs') scope
+              let merged = Token ( concatMap (\(Token x _) -> x) $ inner ++ [rp] ) p
+              in if any (isNewLine Nothing) inner
+                   then []
+                   else findFuncTypeDefs found (merged : xs') scope
             _ -> []
     where myBreakF (Token ")" _) = True
           myBreakF _             = False
@@ -559,5 +558,5 @@ concatTokens = smartUnwords . map (\(Token name _) -> name) .  filter (not . isN
 
 extractOperator :: [Token] -> (String, [Token])
 extractOperator ts@(Token "(" _ : _) =
-    foldr ((++) . tokenString) ")" *** tail $ break ((== ")") . tokenString) ts
+    foldr ((++) . tokenString) ")" *** tail' $ break ((== ")") . tokenString) ts
 extractOperator _ = ("", [])


### PR DESCRIPTION
1. Skip all top-level non-operator areas enclosed in parentheses.
2. Using safe *tail'* in *extractOperator*. With simple `tail`,
   `hasktags -x .` on *http-types* sources (this was in example from
   the issue) fails with `hasktags: Prelude.tail: empty list`: the
   reason of this is that closing `)` cannot be found in some cases.