### PR TITLE
force UTF8 for output files

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -36,7 +36,7 @@ import           System.Directory           (doesDirectoryExist, doesFileExist,
                                               isSymbolicLink)
 #endif
 import           System.FilePath            ((</>))
-import           System.IO                  (Handle, IOMode, hClose, openFile, stdout)
+import           System.IO                  (Handle, IOMode, hClose, openFile, stdout, utf8, hSetEncoding)
 import           Tags                       (FileData (..), FileName,
                                              FoundThing (..),
                                              FoundThingType (FTClass, FTCons, FTConsAccessor, FTConsGADT, FTData, FTDataGADT, FTFuncImpl, FTFuncTypeDef, FTInstance, FTModule, FTNewtype, FTPattern, FTPatternTypeDef, FTType),
@@ -100,7 +100,10 @@ Really not a easy question - maybe there is an answer - I don't know
 getOutFile :: String -> IOMode -> IO Handle
 getOutFile filepath openMode
   | "-" == filepath = return stdout
-  | otherwise       = openFile filepath openMode
+  | otherwise       = do
+    h <- openFile filepath openMode
+    hSetEncoding h utf8
+    pure h
 
 data TagsFile = TagsFile
   { _ctagsFile :: FilePath


### PR DESCRIPTION
I was running hasktags in a nix derivation, where the locale is POSIX. Since GHC doesn't really allow source files to be anything other than UTF8, I think it would be reasonable to unconditionally set the output file encoding, though you might have a different view.