### PR TITLE
Fix #83: Allow bytestring-0.11, CI for GHC 9.2.1, -Wcompat

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210606
+# version: 0.13.20211116
 #
-# REGENDATA ("0.13.20210606",["github","hasktags.cabal"])
+# REGENDATA ("0.13.20211116",["github","hasktags.cabal"])
 #
 name: Haskell-CI
 on:
@@ -20,21 +20,28 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.1
+            compilerKind: ghc
+            compilerVersion: 9.2.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
             compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
@@ -72,9 +79,21 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "$HCNAME" cabal-install-3.4
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -86,11 +105,20 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HCDIR/bin/$HCKIND
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -123,6 +151,10 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions

--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -18,8 +18,9 @@ build-type: Simple
 cabal-version: >=1.10
 
 tested-with:
+  GHC == 9.2.1
   GHC == 9.0.1
-  GHC == 8.10.4
+  GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
@@ -66,32 +67,48 @@ source-repository head
   location: http://github.com/MarcWeber/hasktags
 
 library
-  default-language:  Haskell2010
   hs-source-dirs:    src
-  ghc-options:       -Wall
+  default-language:  Haskell2010
   exposed-modules:   Hasktags
   other-modules:     Tags, DebugShow
   build-depends:
-    utf8-string,
-    base >= 4.8 && < 5,
-    bytestring >= 0.9 && < 0.11,
-    directory >= 1.2.6 && < 1.4,
-    filepath,
-    json >= 0.5 && < 0.11,
-    microlens-platform >= 0.3.8.0 && < 0.5
+      base               >= 4.8     && < 5
+    , bytestring         >= 0.9     && < 0.12
+    , directory          >= 1.2.6   && < 1.4
+    , filepath
+    , json               >= 0.5     && < 0.11
+    , microlens-platform >= 0.3.8.0 && < 0.5
+    , utf8-string
+
+  ghc-options:
+    -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wcompat
+  -- 2021-11-20 Andreas Abel
+  -- GHC 9.2.1 has a new warning about pattern-lambdas and pattern-lets
+  -- that is distracting.
+  if impl(ghc == 9.2.1)
+    ghc-options:
+      -Wno-incomplete-uni-patterns
 
 Executable hasktags
-    Main-Is: src/Main.hs
-    Build-Depends:
-      base,
-      directory,
-      filepath,
-      hasktags,
-      optparse-applicative,
-      containers
-    other-modules: Paths_hasktags
-    ghc-options: -Wall
-    default-language: Haskell2010
+  Main-Is: src/Main.hs
+  default-language: Haskell2010
+  Build-Depends:
+      hasktags
+    , base
+    , containers
+    , directory
+    , filepath
+    , optparse-applicative
+  other-modules: Paths_hasktags
+
+  ghc-options:
+    -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wcompat
 
   if flag(debug)
     cpp-options: -Ddebug
@@ -100,18 +117,23 @@ Test-Suite testsuite
   Type: exitcode-stdio-1.0
   Main-Is: Test.hs
   hs-source-dirs: src, tests
-  Build-Depends:
-                utf8-string,
-                base,
-                bytestring,
-                directory,
-                filepath,
-                json,
-                HUnit,
-                microlens-platform
-  other-modules: Tags, Hasktags, DebugShow
-  ghc-options: -Wall
   default-language: Haskell2010
+  Build-Depends:
+      base
+    , bytestring
+    , directory
+    , filepath
+    , json
+    , microlens-platform
+    , utf8-string
+    , HUnit
+  other-modules: Tags, Hasktags, DebugShow
+
+  ghc-options:
+    -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:
+      -Wcompat
 
   if flag(debug)
     cpp-options: -Ddebug


### PR DESCRIPTION
Fix #83
- allow `bytestring-0.11`
- extend CI to GHC 9.2.1
- ghc-option `-Wcompat`