### PR TITLE
Compatibility with optparse-applicative-0.18

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230321
+# version: 0.16.4
 #
-# REGENDATA ("0.15.20230321",["github","hasktags.cabal"])
+# REGENDATA ("0.16.4",["github","hasktags.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,14 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -173,8 +178,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan

--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -18,8 +18,9 @@ build-type: Simple
 cabal-version: >=1.10
 
 tested-with:
-  GHC == 9.4.4
-  GHC == 9.2.7
+  GHC == 9.6.2
+  GHC == 9.4.5
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,7 +9,7 @@ import Data.Monoid
 import Data.Set (Set, notMember, fromList, union)
 import Data.Version (showVersion)
 import Options.Applicative
-import Options.Applicative.Help.Pretty (text, line)
+import Options.Applicative.Help.Pretty (pretty, line)
 import Paths_hasktags (version)
 import System.Directory (doesFileExist)
 import System.Environment (getArgs)
@@ -161,17 +161,17 @@ parseArgs args parsedOptionFiles = do
              long "version"
           <> help "show version"
 
-        replaceDirsInfo = text $ unwords
+        replaceDirsInfo = pretty $ unwords
           [
             "directories will be replaced by DIR/**/*.hs DIR/**/*.lhs"
           , "Thus hasktags . tags all important files in the current directory."
           ]
-        symlinksInfo = text $ unwords
+        symlinksInfo = pretty $ unwords
           [
             "If directories are symlinks they will not be followed"
           , "unless you pass -L."
           ]
-        stdinInfo = text $ unwords
+        stdinInfo = pretty $ unwords
           [
             "A special file \"STDIN\" will make hasktags read the line separated file "
           , "list to be tagged from STDIN."


### PR DESCRIPTION
- Fix build with optparse-applicative-0.18
  - https://github.com/pcapriotti/optparse-applicative/issues/481
- Bump Haskell CI to GHCs 9.6.2 9.4.5 9.2.8
