### PR TITLE
Fix tuple patterns

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -87,16 +87,6 @@ jobs:
             compilerVersion: 8.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt-get install

--- a/hasktags.cabal
+++ b/hasktags.cabal
@@ -30,8 +30,6 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
-  GHC == 8.2.2
-  GHC == 8.0.2
 
 extra-source-files:
   README.md

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -22,8 +22,9 @@ import qualified Data.ByteString.Char8 as BS (ByteString, readFile, unpack)
 import qualified Data.ByteString.UTF8  as BS8 (fromString)
 import           Data.Char                  (isSpace)
 import           Data.String                (IsString(..))
-import           Data.List                  (isPrefixOf, isSuffixOf, groupBy,
-                                             tails, nub)
+import           Data.List                  (findIndex, isPrefixOf, isSuffixOf,
+                                             groupBy, tails, nub, scanl',
+                                             unfoldr)
 import           Data.Maybe                 (mapMaybe, maybeToList)
 import           DebugShow                  (trace_)
 import           System.Directory           (doesDirectoryExist, doesFileExist,
@@ -566,24 +567,52 @@ concatTokens = smartUnwords . mapMaybe _TokenName
         glueNext (a, "")      = a
         glueNext (a, _)       = a ++ " "
 
+{- | 'splitDropWhen' @p xs@ splits @xs@ at those elements satisfying @p@,
+dropping those elements. Equivalently, it breaks @xs@ into contiguous
+segments of elements not satisfying @p@
+-}
+splitDropWhen :: (a -> Bool) -> [a] -> [[a]]
+splitDropWhen p = unfoldr $ \es ->
+  if null es
+    then Nothing
+    else Just (breakDrop p es)
+
+{- | 'breakDrop' @p xs@ returns a tuple whose first element is the longest
+prefix of @xs@ not satsifying @p@, and whose second element is the longest
+suffix of the remainder of @xs@ not starting with an element satisfying @p@.
+-}
+breakDrop :: (a -> Bool) -> [a] -> ([a], [a])
+breakDrop p xs =
+  let
+    (pre, t) = break p xs
+    (_, post) = break (not . p) t
+   in
+    (pre, post)
+
 commaSep :: [Token] -> [[Token]]
-commaSep = go True [] where
-  go _   acc [] = filter (not . null) $ reverse acc
-  go _   acc (Token "," _ : ts) = go True acc ts
-  go new acc (t : ts) = go False acc' ts
-    where
-    acc'
-      | new = [t] : acc
-      | a:as <- acc = (t:a) : as
-      | otherwise = [[t]]
+commaSep = filter (not . null) . splitDropWhen ((== ",") . tokenString)
 
 extractOperator :: [Token] -> ([String], [Token])
-extractOperator (Token "(" _ : ts) = (names, post)
-  where
-  (pre, _:post) = break ((== ")") . tokenString) ts
-  flatNames = foldr ((++) . tokenString) "" . filter (not . isNewLine Nothing)
-  names = case commaSep ts of
-    [only] -> ["(" ++ flatNames ts ++ ")"]
+extractOperator ts@(Token "(" _ : _) = (names, post)
+ where
+  -- The index of the closing parenthesis in a parenthesized set of nested parens
+  -- (detected as the paren making the nesting level =0)
+  parenSpan =
+    maybe 0 (+1)
+    . findIndex (==0) . drop 1 . scanl' (+) 0 . map nestingDelta
+   where
+      nestingDelta :: Token -> Int
+      nestingDelta (Token "(" _) = 1
+      nestingDelta (Token ")" _) = -1
+      nestingDelta _             = 0
+  -- by splitting just before the closing paren, we save having to rewalk the
+  -- string to deparenthesize the external parentheses
+  (pre, post) = both (drop 1) $ splitAt (parenSpan ts - 1) ts
+   where
+    both f (x, y) = (f x, f y)
+  flatNames = concat . mapMaybe _TokenName
+  names = case commaSep pre of
+    [only] -> ["(" ++ flatNames only ++ ")"]
     tss -> map flatNames tss
 -- impossible
 extractOperator _ = ([], [])

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -24,7 +24,7 @@ import           Data.Char                  (isSpace)
 import           Data.String                (IsString(..))
 import           Data.List                  (isPrefixOf, isSuffixOf, groupBy,
                                              tails, nub)
-import           Data.Maybe                 (maybeToList)
+import           Data.Maybe                 (mapMaybe, maybeToList)
 import           DebugShow                  (trace_)
 import           System.Directory           (doesDirectoryExist, doesFileExist,
                                              getDirectoryContents,
@@ -149,6 +149,14 @@ isNewLine :: Maybe Int -> Token -> Bool
 isNewLine Nothing (NewLine _)   = True
 isNewLine (Just c) (NewLine c') = c == c'
 isNewLine _ _                   = False
+
+_TokenName :: Token -> Maybe String
+_TokenName (Token s _) = Just s
+_TokenName _           = Nothing
+
+_NewLine :: Maybe Int -> Token -> Maybe Int
+_NewLine m t@(NewLine i) | isNewLine m t = Just i
+_NewLine _ _                             = Nothing
 
 trimNewlines :: [Token] -> [Token]
 trimNewlines = filter (not . isNewLine Nothing)
@@ -417,7 +425,7 @@ findFuncTypeDefs found (t@(Token _ _): Token "::" _ : sig) scope =
 findFuncTypeDefs found xs@(Token "(" _ :_) scope =
           case break myBreakF xs of
             (inner@(Token _ p : _), rp : xs') ->
-              let merged = Token ( concatMap (\(Token x _) -> x) $ inner ++ [rp] ) p
+              let merged = Token ( concat . mapMaybe _TokenName $ inner ++ [rp] ) p
               in if any (isNewLine Nothing) inner
                    then []
                    else findFuncTypeDefs found (merged : xs') scope
@@ -433,8 +441,7 @@ fromWhereOn (_: xs@(NewLine _ : _)) scope =
              concatMap (flip findstuff scope . tail')
              $ splitByNL (Just ( minimum
                                 . (10000:)
-                                . map (\(NewLine i) -> i)
-                                . filter (isNewLine Nothing) $ xs)) xs
+                                . mapMaybe (_NewLine Nothing) $ xs)) xs
 fromWhereOn (_:xw) scope = findstuff xw scope
 
 findFunc :: [Token] -> Scope -> [FoundThing]
@@ -548,7 +555,7 @@ dirToFiles followSyms suffixes p = do
   where matchingSuffix = any (`isSuffixOf` p) suffixes
 
 concatTokens :: [Token] -> String
-concatTokens = smartUnwords . map (\(Token name _) -> name) .  filter (not . isNewLine Nothing)
+concatTokens = smartUnwords . mapMaybe _TokenName
   where smartUnwords [] = []
         smartUnwords a = foldr (\v -> (glueNext v ++)) "" $ a `zip` tail (a ++ [""])
         glueNext (a@("("), _) = a

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -17,14 +17,13 @@ module Hasktags (
   dirToFiles
 ) where
 import           Control.Monad              (when)
-import           Control.Arrow              ((***))
 import qualified Data.ByteString.Char8 as BS (ByteString, readFile, unpack)
 import qualified Data.ByteString.UTF8  as BS8 (fromString)
 import           Data.Char                  (isSpace)
 import           Data.String                (IsString(..))
 import           Data.List                  (findIndex, isPrefixOf, isSuffixOf,
-                                             groupBy, tails, nub, scanl',
-                                             unfoldr)
+                                             tails, nub, scanl', unfoldr)
+import qualified Data.List.NonEmpty as NE
 import           Data.Maybe                 (mapMaybe, maybeToList)
 import           DebugShow                  (trace_)
 import           System.Directory           (doesDirectoryExist, doesFileExist,
@@ -224,8 +223,7 @@ findThingsInBS filename bs = do
         let aslines = lines $ BS.unpack bs
 
         let stripNonHaskellLines = let
-                  emptyLine = all (all isSpace . tokenString)
-                            . filter (not . isNewLine Nothing)
+                  emptyLine = all (all isSpace . tokenString) . trimNewlines
                   cppLine (_nl:t:_) = ("#" `isPrefixOf`) $ tokenString t
                   cppLine _         = False
                 in filter (not . emptyLine) . filter (not . cppLine)
@@ -267,27 +265,27 @@ findThingsInBS filename bs = do
         --     z = 20
         -- won't be found as function
         let topLevelIndent = debugStep "top level indent" $ getTopLevelIndent isLiterate tokenLines
-        let sections = map tail -- strip leading NL (no longer needed)
+        let sections = map (drop 1) -- strip leading NL (no longer needed)
                        $ filter (not . null)
                        $ splitByNL (Just topLevelIndent )
                        $ concat (trace_ "tokenLines" tokenLines tokenLines)
         -- only take one of
         -- a 'x' = 7
         -- a _ = 0
-        let filterAdjacentFuncImpl = map head . groupBy (\(FoundThing t1 n1 (Pos f1 _ _ _))
-                                                          (FoundThing t2 n2 (Pos f2 _ _ _))
-                                                          -> f1 == f2
-                                                            && n1 == n2
-                                                            && areFuncImpls t1 t2)
+        let filterAdjacentFuncImpl = map NE.head . NE.groupBy (
+              \(FoundThing t1 n1 (Pos f1 _ _ _))
+               (FoundThing t2 n2 (Pos f2 _ _ _))
+               -> f1 == f2 && n1 == n2 && areFuncImpls t1 t2)
             areFuncImpls (FTFuncImpl _) (FTFuncImpl _) = True
             areFuncImpls _ _                           = False
 
-        let iCI = map head . groupBy (\(FoundThing t1 n1 (Pos f1 l1 _ _))
-                                       (FoundThing t2 n2 (Pos f2 l2 _ _))
-                                       -> f1 == f2
-                                         && n1 == n2
-                                         && skipCons t1 t2
-                                         && ((<= 7) $ abs $ l2 - l1))
+        let iCI = map NE.head . NE.groupBy (
+                \(FoundThing t1 n1 (Pos f1 l1 _ _))
+                 (FoundThing t2 n2 (Pos f2 l2 _ _))
+                 -> f1 == f2
+                    && n1 == n2
+                    && skipCons t1 t2
+                    && ((<= 7) $ abs $ l2 - l1))
             skipCons FTData (FTCons _ _)       = False
             skipCons FTDataGADT (FTConsGADT _) = False
             skipCons _ _                       = True
@@ -421,8 +419,9 @@ findstuff xs scope =
 findFuncTypeDefs :: [Token] -> [Token] -> Scope -> [FoundThing]
 findFuncTypeDefs found (t@(Token _ _): Token "," _ :xs) scope =
           findFuncTypeDefs (t : found) xs scope
-findFuncTypeDefs found (t@(Token _ _): Token "::" _ : sig) scope =
-          map (\(Token name p) -> FoundThing (FTFuncTypeDef (concatTokens sig) scope) name p) (t:found)
+findFuncTypeDefs found (t@(Token _ _): Token "::" _ : sig) scope = [
+          FoundThing (FTFuncTypeDef (concatTokens sig) scope) name p
+          | Token name p <- (t:found)]
 findFuncTypeDefs found xs@(Token "(" _ :_) scope =
           case break myBreakF xs of
             (inner@(Token _ p : _), rp : xs') ->
@@ -505,9 +504,8 @@ splitByNL _ _ = []
 getTopLevelIndent :: Bool -> [[Token]] -> Int
 getTopLevelIndent _ [] = 0 -- (no import found, assuming indent 0: this can be
                            -- done better but should suffice for most needs
-getTopLevelIndent isLiterate ((nl:next:_):xs) = if "import" == tokenString next
-                          then let (NewLine i) = nl in i
-                          else getTopLevelIndent isLiterate xs
+getTopLevelIndent _ ((nl:next:_):_) |
+  "import" == tokenString next, (NewLine i) <- nl = i
 getTopLevelIndent isLiterate (_:xs) = getTopLevelIndent isLiterate xs
 
 -- According to http://www.haskell.org/onlinereport/literate.html either
@@ -550,7 +548,7 @@ dirToFiles followSyms suffixes p = do
         then return []
         else do
           -- filter . .. and hidden files .*
-          contents <- filter ((/=) '.' . head) `fmap` getDirectoryContents p
+          contents <- filter (not . isPrefixOf ".") `fmap` getDirectoryContents p
           concat `fmap` mapM (dirToFiles followSyms suffixes . (</>) p) contents
     else return [p | matchingSuffix ]
   where matchingSuffix = any (`isSuffixOf` p) suffixes
@@ -558,7 +556,7 @@ dirToFiles followSyms suffixes p = do
 concatTokens :: [Token] -> String
 concatTokens = smartUnwords . mapMaybe _TokenName
   where smartUnwords [] = []
-        smartUnwords a = foldr (\v -> (glueNext v ++)) "" $ a `zip` tail (a ++ [""])
+        smartUnwords a = foldr (\v -> (glueNext v ++)) "" $ a `zip` drop 1 (a ++ [""])
         glueNext (a@("("), _) = a
         glueNext (a, ")")     = a
         glueNext (a@("["), _) = a

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,7 +5,6 @@ module Main (main) where
 import Hasktags
 
 import Control.Monad (unless)
-import Data.Monoid
 import Data.Set (Set, notMember, fromList, union)
 import Data.Version (showVersion)
 import Options.Applicative

--- a/testcases/multidefinition.hs
+++ b/testcases/multidefinition.hs
@@ -1,0 +1,17 @@
+-- to be found a
+-- to be found b
+-- to be found c
+-- to be found d
+-- to be found e
+-- to be found f
+-- to be found g
+-- to be found (@)
+-- to be found (#)
+
+(a, b) = undefined
+(c,
+ d) = undefined
+(   e
+ ,  f,
+ g  ) = undefined
+((@), (#)) = ((*),(+))


### PR DESCRIPTION

https://github.com/MarcWeber/hasktags/pull/99 attempted to fix multiline tuple patterns, but in the process broke some test. In fact, it turns out tuple patterns were underexercised in tests, so we were lucky to catch this (it also broke the handling of prefix operator definitions). Moreover, the logic in that PR was hard to understand in places.
This PR fixes this by replacing the tuple-splitting logic by a simple `unfold` splitting on delimiters.
Also, to silence GHC warnings, it introduces two prisms `_TokenName` and `_NewLine` to use instead of eg `map (\(NewLine x ...) -> x) . filter isNewLine`.

Closes: #101
Fixes: #99
