### PR TITLE
Improve block comment stripping and operator/tuple parsing

### DIFF
--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -19,7 +19,7 @@ module Hasktags (
 import           Control.Monad              (when)
 import           Control.Arrow              ((***))
 import qualified Data.ByteString.Char8 as BS (ByteString, readFile, unpack)
-import qualified Data.ByteString.UTF8  as BS8 (fromString)
+import qualified Data.ByteString.UTF8  as BS8 (fromString, toString)
 import           Data.Char                  (isSpace)
 import           Data.String                (IsString(..))
 import           Data.List                  (isPrefixOf, isSuffixOf, groupBy,
@@ -197,14 +197,6 @@ findWithCache cache filename = do
           when cache (writeFile cacheFilename (encodeJSON filedata))
           return filedata
 
--- eg Data.Text says that using ByteStrings could be fastest depending on ghc
--- platform and whatnot - so let's keep the hacky BS.readFile >>= BS.unpack
--- usage till there is a problem, still need to match utf-8 chars like this: ⇒
--- to get correct class names, eg MonadBaseControl case (testcase testcases/monad-base-control.hs)
--- so use the same conversion which is applied to files when they got read ..
-utf8_to_char8_hack :: String -> String
-utf8_to_char8_hack = BS.unpack . BS8.fromString
-
 -- Find the definitions in a file
 findThings :: FileName -> IO FileData
 findThings filename =
@@ -212,7 +204,7 @@ findThings filename =
 
 findThingsInBS :: String -> BS.ByteString -> FileData
 findThingsInBS filename bs = do
-        let aslines = lines $ BS.unpack bs
+        let aslines = lines $ BS8.toString bs
 
         let stripNonHaskellLines = let
                   emptyLine = all (all isSpace . tokenString)
@@ -378,7 +370,7 @@ findstuff tokens@(Token "class" _ : xs) _ =
             = case (head'
                   . dropWhile isParenOpen
                   . reverse
-                  . takeWhile ((not . (`elem` ["=>", utf8_to_char8_hack "⇒"])) . tokenString)
+                  . takeWhile ((not . (`elem` ["=>", "⇒"])) . tokenString)
                   . reverse) lst of
               (Just (Token name p)) -> Just $ FoundThing FTClass name p
               _                     -> Nothing

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -240,7 +240,7 @@ findThingsInBS filename bs = do
                         debugStep "stripNonHaskellLines" $ stripNonHaskellLines
                       $ debugStep "stripslcomments" $ stripslcomments
                       $ debugStep "splitByNL" $ splitByNL Nothing
-                      $ debugStep "stripblockcomments pipe" $ stripblockcomments
+                      $ debugStep "stripblockcomments pipe" $ stripblockcomments 0
                       $ concat
                       $ zipWith3 (withline filename)
                                  (map
@@ -314,22 +314,17 @@ stripslcomments = let f (NewLine _ : Token ('-':'-':_) _ : _) = False
                       isCmt _                                 = False
                   in map (takeWhile (not . isCmt)) . filter f
 
-stripblockcomments :: [Token] -> [Token]
-stripblockcomments (Token "{-" pos : xs) =
-  trace_ "{- found at " (show pos) $
-  afterblockcomend xs
-stripblockcomments (x:xs) = x:stripblockcomments xs
-stripblockcomments [] = []
-
-afterblockcomend :: [Token] -> [Token]
-afterblockcomend (t@(Token _ pos):xs)
- | contains "-}" (tokenString t) =
-   trace_ "-} found at " (show pos) $
-   stripblockcomments xs
- | otherwise           = afterblockcomend xs
-afterblockcomend [] = []
-afterblockcomend (_:xs) = afterblockcomend xs
-
+stripblockcomments :: Int -> [Token] -> [Token]
+stripblockcomments nest (t:ts)
+  | Token str pos <- t, "{-" `isPrefixOf` str
+  = trace_ (str ++ " found at") (show pos)
+  $ stripblockcomments (nest+1) ts
+  | nest <= 0 = t:stripblockcomments nest ts
+  | Token str pos <- t, "-}" `isSuffixOf` str
+  = trace_ (str ++ " found at ") (show pos)
+  $ stripblockcomments (max 0 (nest-1)) ts
+  | otherwise = stripblockcomments nest ts
+stripblockcomments _ [] = []
 
 -- does one string contain another string
 

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -440,7 +440,8 @@ findInfix x scope
 
 findF :: [Token] -> Scope -> [FoundThing]
 findF ts@(Token "(" p : _) scope =
-    let (names, xs) = extractOperator ts in
+    let (names0, xs) = extractOperator ts
+        names = filter ((/= "()")) names0 in
     [FoundThing (FTFuncImpl scope) name p | name <- names, any (("=" ==) . tokenString) xs]
 findF (Token name p : xs) scope =
     [FoundThing (FTFuncImpl scope) name p | any (("=" ==) . tokenString) xs]

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -563,7 +563,7 @@ extractOperator (Token "(" _ : ts) = (names, post)
   (pre, _:post) = break ((== ")") . tokenString) ts
   flatNames = foldr ((++) . tokenString) "" . filter (not . isNewLine Nothing)
   names = case commaSep ts of
-    [only] -> ["(" ++ flatNames ts ++ ")"]
+    [only] -> ["(" ++ flatNames pre ++ ")"]
     tss -> map flatNames tss
 -- impossible
 extractOperator _ = ([], [])

--- a/src/Hasktags.hs
+++ b/src/Hasktags.hs
@@ -20,7 +20,7 @@ import           Control.Monad              (when)
 import           Control.Arrow              ((***))
 import qualified Data.ByteString.Char8 as BS (ByteString, readFile, unpack)
 import qualified Data.ByteString.UTF8  as BS8 (fromString, toString)
-import           Data.Char                  (isSpace)
+import           Data.Char                  (isAlpha, isSpace)
 import           Data.String                (IsString(..))
 import           Data.List                  (isPrefixOf, isSuffixOf, groupBy,
                                              tails, nub)
@@ -557,13 +557,40 @@ commaSep = go True [] where
       | a:as <- acc = (t:a) : as
       | otherwise = [[t]]
 
+-- Breaks a token stream at an appropriate closing paren,
+-- assuming one had just been removed from the input stream.
+-- The closing paren is omitted.
+--
+-- Matching parentheses are kept track of, so breaking
+--
+--   ((+++), (---))
+--
+-- will work correctly.
+parenBreak :: [Token] -> ([Token], [Token])
+parenBreak = go 1 [] where
+  adj t lvl
+    | tokenString t == "(" = lvl+1
+    | tokenString t == ")" = lvl-1
+    | otherwise = lvl
+
+  go lvl acc ts
+    | lvl <= 0   = (reverse $ drop 1 acc, ts)
+    | [] <- ts   = (reverse acc, [])
+    | t:ts <- ts = go (adj t lvl) (t:acc) ts
+
 extractOperator :: [Token] -> ([String], [Token])
 extractOperator (Token "(" _ : ts) = (names, post)
   where
-  (pre, _:post) = break ((== ")") . tokenString) ts
-  flatNames = foldr ((++) . tokenString) "" . filter (not . isNewLine Nothing)
-  names = case commaSep ts of
-    [only] -> ["(" ++ flatNames pre ++ ")"]
+  fixOper s
+    | c:_ <- s, isAlpha c || c == '_' = s
+    | otherwise = "(" ++ s ++ ")"
+
+  (pre, post) = parenBreak ts
+
+  flatNames = foldr ((++) . tokenString) "" . reverse . filter (not . isNewLine Nothing)
+
+  names = case commaSep pre of
+    [only] -> [fixOper $ flatNames only]
     tss -> map flatNames tss
 -- impossible
 extractOperator _ = ([], [])

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -41,11 +41,16 @@ isWord c = isAlpha c || c == '_'
 
 -- continuation characters for words
 isWord' :: Char -> Bool
-isWord' c = isAlphaNum c || c == '_' || c == '#'
+isWord' c = isAlphaNum c || c == '_' || c == '#' || c == '\'' || c == '.'
 
 -- operator characters
 isOper :: Char -> Bool
-isOper c = not (isWord c || isSpace c || isPunc c)
+isOper c = not
+   $ isAlphaNum c
+  || c == '\''
+  || c == '"'
+  || isSpace c
+  || isPunc c
 
 -- punctuation characters
 isPunc :: Char -> Bool
@@ -69,7 +74,8 @@ tokspan (',':cs) = (",", cs)
 tokspan s@(c:_)
   | isWord c = span isWord' s
   | isNumber c = span isNumber s
-  | otherwise = span isOper s
+  | isOper c = span isOper s
+  | otherwise = span (not . isSpace) s
 
 type FileName = String
 

--- a/src/Tags.hs
+++ b/src/Tags.hs
@@ -5,47 +5,71 @@
 -- yes, this is still specific to hasktags :(
 module Tags where
 import           Control.Monad       (when)
-import           Data.Char           (isSpace)
+import           Data.Char           (isSpace, isNumber, isAlpha, isAlphaNum)
 import           Data.Data           (Data, Typeable)
 import           Data.List           (sortBy, intercalate)
+import           Data.Maybe          (fromMaybe)
 import           Lens.Micro.Platform
 import           System.IO           (Handle, hPutStr, hPutStrLn)
 
 -- my words is mainly copied from Data.List.
 -- difference abc::def is recognized as three words
 -- `abc` is recognized as "`" "abc" "`"
-mywords :: Bool -> String -> [String]
-mywords spaced s =  case rest of
-                        ')':xs -> (blanks' ++ ")") : mywords spaced xs
-                        "" -> []
-                        '{':'-':xs -> (blanks' ++ "{-") : mywords spaced xs
-                        '-':'}':xs -> (blanks' ++ "-}") : mywords spaced xs
-                        '{':xs -> (blanks' ++ "{") : mywords spaced xs
-                        '(':xs -> (blanks' ++ "(") : mywords spaced xs
-                        '`':xs -> (blanks' ++ "`") : mywords spaced xs
-                        '=':'>':xs -> (blanks' ++ "=>") : mywords spaced xs
-                        '=':xs -> (blanks' ++ "=") : mywords spaced xs
-                        ',':xs -> (blanks' ++ ",") : mywords spaced xs
-                        ':':':':xs -> (blanks' ++ "::") : mywords spaced xs
-                        s' -> (blanks' ++ w) : mywords spaced s''
-                              where (w, s'') = myBreak s'
-                                    myBreak [] = ([],[])
-                                    myBreak (':':':':xs) = ([], "::"++xs)
-                                    myBreak (')':xs) = ([],')':xs)
-                                    myBreak ('(':xs) = ([],'(':xs)
-                                    myBreak ('`':xs) = ([],'`':xs)
-                                    myBreak ('=':xs) = ([],'=':xs)
-                                    myBreak (',':xs) = ([],',':xs)
-                                    myBreak xss@(x:xs)
-                                      | isSpace x
-                                        = if spaced
-                                          then ([], xss)
-                                          else ([], dropWhile isSpace xss)
-                                      | otherwise = let (a,b) = myBreak xs
-                                                    in  (x:a,b)
-                    where blanks' = if spaced then blanks else ""
-                          (blanks, rest) = span {-partain:Char.-}isSpace s
 
+-- special cases for tokens from non-uniform character classes
+special :: String -> Maybe (String, String)
+special ('{':'-':'#':s) = Just ("{-#", s)
+special ('#':'-':'}':s) = Just ("#-}", s)
+special ('{':'-':s) = Just ("{-", s)
+special ('-':'}':s) = Just ("-}", s)
+special _ = Nothing
+
+-- tokenizes a string based on rough syntactic categories
+mywords :: Bool -> String -> [String]
+mywords spaced = go . preTrim where
+  preTrim = span isSpace
+
+  go (blanks, []) = []
+  go (blanks, s)
+    | blanks <- if spaced then blanks else ""
+    , (t, s) <- fromMaybe (tokspan s) (special s)
+    = (blanks ++ t) : go (preTrim s) where
+
+-- beginning word characters
+isWord :: Char -> Bool
+isWord c = isAlpha c || c == '_'
+
+-- continuation characters for words
+isWord' :: Char -> Bool
+isWord' c = isAlphaNum c || c == '_' || c == '#'
+
+-- operator characters
+isOper :: Char -> Bool
+isOper c = not (isWord c || isSpace c || isPunc c)
+
+-- punctuation characters
+isPunc :: Char -> Bool
+isPunc c = any (c ==) "()[]{},`"
+
+-- Spans a single token. Punctuation is special cased to yield single
+-- tokens (compound tokens involving these characters are assumed to
+-- have already been handled). Otherwise we grab runs of characters
+-- matching the first. Leading spaces are also assumed to have been
+-- removed already.
+tokspan :: String -> (String, String)
+tokspan [] = ([], [])
+tokspan ('(':cs) = ("(", cs)
+tokspan (')':cs) = (")", cs)
+tokspan ('{':cs) = ("{", cs)
+tokspan ('}':cs) = ("}", cs)
+tokspan ('[':cs) = ("[", cs)
+tokspan (']':cs) = ("]", cs)
+tokspan ('`':cs) = ("`", cs)
+tokspan (',':cs) = (",", cs)
+tokspan s@(c:_)
+  | isWord c = span isWord' s
+  | isNumber c = span isNumber s
+  | otherwise = span isOper s
 
 type FileName = String
 

--- a/testcases/tuple-match.hs
+++ b/testcases/tuple-match.hs
@@ -1,0 +1,21 @@
+-- to be found c
+-- to be found d
+-- to be found _w
+-- to be found w
+-- to be found x
+-- to be found y
+-- to be found z
+-- to be found (+)
+-- to be found (-)
+
+(c, d) = (1, 2)
+
+(x,
+ y,
+ z) = (1, 2, 3)
+
+(w) = 1
+
+(_w) = 2
+
+((+), (-)) = (\x y -> x, \x y -> y)

--- a/testcases/tuple-match.hs
+++ b/testcases/tuple-match.hs
@@ -7,6 +7,7 @@
 -- to be found z
 -- to be found (+)
 -- to be found (-)
+-- not to be found ()
 
 (c, d) = (1, 2)
 
@@ -18,4 +19,4 @@
 
 (_w) = 2
 
-((+), (-)) = (\x y -> x, \x y -> y)
+((+), (-), ()) = (\x y -> x, \x y -> y, ())

--- a/testcases/unspaced-block-comments.hs
+++ b/testcases/unspaced-block-comments.hs
@@ -1,0 +1,11 @@
+-- to be found E
+-- to be found F
+-- not to be found bar
+
+{-
+foo = readFile#{-NB-}
+
+bar = 5
+-}
+
+data E = F


### PR DESCRIPTION
This includes two changes.

1. Rewrote the tokenizer to be a bit more reliable about properly tokenizing various Haskell lexemes. This handles some cases that occur in e.g. GHC. For instance, there was code like:

       readLine#{-NB-}

   which would tokenize as (I think) a single token, and then get treated as `-}`. If not quite that, it was at least getting lexed as something like `readLine#{-` which didn't get recognized as an opener.

2. Changed the block comment stripping to handle nested comments. This is accomplished by keeping track of a nesting level, incrementing when we see a `{-`, decrementing when we see a `-}`, and throwing away other tokens while the nesting level is above 0. It doesn't try to handle comment tokens inside strings within block comments, so it may not be completely correct.

The second needs the first to work well, because otherwise you're not getting the open/close bits as individual tokens. But you need the second to actually run `hasktags` on GHC, because the offending example was actually in the middle of another block comment.